### PR TITLE
Show currently selected CHR index information

### DIFF
--- a/NES CHR Editor/NES CHR Editor/Base.lproj/Main.storyboard
+++ b/NES CHR Editor/NES CHR Editor/Base.lproj/Main.storyboard
@@ -380,6 +380,14 @@
                                     <segue destination="A66-Qe-H8A" kind="embed" identifier="embedPaletteColor" id="N01-4i-5Vk"/>
                                 </connections>
                             </containerView>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qmt-NT-tQd">
+                                <rect key="frame" x="351" y="10" width="196" height="128"/>
+                                <textFieldCell key="cell" lineBreakMode="truncatingTail" title="Label" id="s6S-kX-gZZ">
+                                    <font key="font" size="13" name="Monaco"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="Z37-92-vyl" secondAttribute="bottom" constant="10" id="1Lc-aF-oUH"/>
@@ -388,6 +396,8 @@
                             <constraint firstItem="sWB-kj-iRJ" firstAttribute="leading" secondItem="6Nm-ug-xGm" secondAttribute="leading" id="57b-KI-INk"/>
                             <constraint firstAttribute="trailing" secondItem="6Nm-ug-xGm" secondAttribute="trailing" constant="10" id="8hA-El-unu"/>
                             <constraint firstItem="mtc-3K-6lt" firstAttribute="top" secondItem="6Nm-ug-xGm" secondAttribute="bottom" constant="15" id="A5O-Ae-KqK"/>
+                            <constraint firstItem="qmt-NT-tQd" firstAttribute="leading" secondItem="Z37-92-vyl" secondAttribute="trailing" constant="15" id="As6-7h-0EL"/>
+                            <constraint firstItem="qmt-NT-tQd" firstAttribute="top" secondItem="zAz-4I-8wR" secondAttribute="bottom" constant="8" id="BlI-DU-4Fs"/>
                             <constraint firstItem="sWB-kj-iRJ" firstAttribute="top" secondItem="5iD-pS-Nc8" secondAttribute="bottom" id="Ftc-3I-diG"/>
                             <constraint firstItem="zAz-4I-8wR" firstAttribute="leading" secondItem="6Nm-ug-xGm" secondAttribute="leading" id="KJp-x7-D4d"/>
                             <constraint firstItem="zAz-4I-8wR" firstAttribute="trailing" secondItem="6Nm-ug-xGm" secondAttribute="trailing" id="LPi-t9-87K"/>
@@ -412,6 +422,7 @@
                         <outlet property="palletteView1" destination="v3v-H2-w3d" id="vii-di-ShL"/>
                         <outlet property="palletteView2" destination="HGr-7a-i64" id="5b0-Zn-W4P"/>
                         <outlet property="palletteView3" destination="f9Q-lR-exY" id="bxY-bp-WMa"/>
+                        <outlet property="selectionLabel" destination="qmt-NT-tQd" id="Rde-c2-7RJ"/>
                         <segue destination="sf9-JZ-Ehp" kind="modal" identifier="presentFileSelectionDialog" id="EXO-VL-qtU"/>
                     </connections>
                 </viewController>

--- a/NES CHR Editor/NES CHR Editor/ViewControllers/EditorViewController.swift
+++ b/NES CHR Editor/NES CHR Editor/ViewControllers/EditorViewController.swift
@@ -28,7 +28,7 @@ protocol FileEditProtocol {
     func fileWasEdited()
 }
 
-class EditorViewController: NSViewController, FileEditProtocol, FileSizeSelectionProtocol, PaletteColorSelectionProtocol, PalettePresetSelectionProtocol, NSWindowDelegate{
+class EditorViewController: NSViewController, FileEditProtocol, FileSizeSelectionProtocol, PaletteColorSelectionProtocol, PalettePresetSelectionProtocol, CHRSelectionProtocol, NSWindowDelegate{
 
     var fullGridCollectionView:FullGridCollectionViewController?
     @IBOutlet weak var editView:EditView!
@@ -37,6 +37,8 @@ class EditorViewController: NSViewController, FileEditProtocol, FileSizeSelectio
     @IBOutlet weak var palletteView1:NSView!
     @IBOutlet weak var palletteView2:NSView!
     @IBOutlet weak var palletteView3:NSView!
+    
+    @IBOutlet weak var selectionLabel:NSTextField!
     
     var shouldShowFileSizeSelectionDialog = false
     var windowControllerDelegate:WindowControllerProtocol?
@@ -64,7 +66,7 @@ class EditorViewController: NSViewController, FileEditProtocol, FileSizeSelectio
             vc.fileSizeSelectionDelegate = self
         } else if let vc = segue.destinationController as? FullGridCollectionViewController {
             vc.fileEditDelegate = self
-            vc.tileSelectionDelegate = self.editView
+            vc.tileSelectionDelegate = self
             self.editView.tileEditDelegate = vc
             self.editView.gridHistoryDelegate = vc
             self.fullGridCollectionView = vc
@@ -309,6 +311,31 @@ class EditorViewController: NSViewController, FileEditProtocol, FileSizeSelectio
         self.palletteView1.setNeedsDisplay(self.palletteView1.bounds)
         self.palletteView2.setNeedsDisplay(self.palletteView2.bounds)
         self.palletteView3.setNeedsDisplay(self.palletteView3.bounds)
+        
+        self.renderSelectedOffset()
+    }
+    
+    // Renders useful information about the selected CHR index to selectionLabel
+    private func renderSelectedOffset() {
+        if let safeCHRIndex = self.fullGridCollectionView?.grid.selectedCHRIndex {
+            // Which pattern table this index is in
+            let table = String(format:"%3d", safeCHRIndex / 256)
+            // Index relative to the pattern table
+            let relativeIndex = safeCHRIndex % 256
+            // Formatted string for the actual index
+            let chrString = String(format:"%3d", safeCHRIndex)
+            // Formatted string for the relative index
+            let relativeString = String(format:"%3d", relativeIndex)
+            // Asm formatted hex string for the relative index
+            let relativeHex = String(format:"%02X", relativeIndex)
+            
+            selectionLabel.stringValue = "Selection\n Index:\t\t\(chrString)\n Table:\t\t\(String(table))\n Offset:\t\(relativeString)\n Hex:\t\t$\(relativeHex)"
+        }
+    }
+    
+    func tileSelected(withCHR aCHR: CHR) {
+        self.editView.tileSelected(withCHR: aCHR)
+        renderSelectedOffset()
     }
     
     // MARK: - NSWindowDelegate

--- a/NES CHR Editor/NES CHR Editor/Views/EditView.swift
+++ b/NES CHR Editor/NES CHR Editor/Views/EditView.swift
@@ -8,7 +8,7 @@
 
 import AppKit
 
-class EditView: NSView, CHRSelectionProtocol {
+class EditView: NSView {
     
     var tileEditDelegate:CHREditProtocol?
     var gridHistoryDelegate:CHRGridHistoryProtocol?


### PR DESCRIPTION
I recently started working on a homebrew NES project. After finishing the tutorials I can find online (which all seem to use mario.chr as a de-facto default) I wanted to start creating some graphics of my own. I've been very happy to find your NES CHR editor, since I'm working on macOS!

I'm writing assembly from scratch to load CHR data in my NES rom, and I need to know a given tile's address relative to whichever of the two pattern tables it is in. Individual tiles are addressed by a single byte, for example, $F0.

To this end, I've added a small text box with a little bit of descriptive information about the tile that is currently selected for editing.

Here's how the label looks in-app, I've selected index 54 in each pattern table so you can see how the content renders:

mario.chr index 54 Table 0
<img width="553" alt="index_54_table_0" src="https://user-images.githubusercontent.com/17522941/92339999-929bb180-f06d-11ea-86db-b30d2900cc53.png">

mario.chr index 54 Table 1
<img width="554" alt="index_54_table_1" src="https://user-images.githubusercontent.com/17522941/92340036-b5c66100-f06d-11ea-92e8-6093cf21661e.png">

The changes I've made are as follows:
- Added a label to the bottom right of the storyboard. Chose a default monospace font since we're rendering numbers
- Intercept tileSelected events in EditorViewController. To this end, EditView no longer implements CHRSelectionProtocol, and EditorViewController does.
- Whenever EditorViewController.refreshControls or tileSelected are called, the contents of the label are refreshed, displaying:
  - The currently selected tile index
  - Which pattern table the index is in
  - The decimal index relative to the pattern table
  - An asm formatted hex version of the relative index, for use in addressing

 I'm no Swift expert, so I'm definitely open to refactoring this process in a more sane way, if that's desired!

Thanks a ton for your work on this app!